### PR TITLE
Added in monospace as the fallback font in case Ubuntu Mono doesn't load

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -177,7 +177,7 @@
 			"dropCap": false,
 			"fontFamilies": [
 				{
-					"fontFamily": "\"Ubuntu Mono\", serif",
+					"fontFamily": "\"Ubuntu Mono\", monospace",
 					"name": "Ubuntu Mono",
 					"slug": "ubuntu-mono",
 					"fontFace": [


### PR DESCRIPTION
Added in monospace as the fallback font in case Ubuntu Mono doesn't load.

Closes #21